### PR TITLE
update request version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/dionoid/koa-request/issues"
   },
   "dependencies": {
-    "request": "*"
+    "request": "~2.74.0"
   },
   "homepage": "https://github.com/dionoid/koa-request",
   "directories": {


### PR DESCRIPTION
the version `2.75.0` of request has some bugs, block our `form-data` post data to be sended.
